### PR TITLE
Allow formatting of entire file on empty selection

### DIFF
--- a/PrettyRuby.sublime-settings
+++ b/PrettyRuby.sublime-settings
@@ -3,5 +3,8 @@
   "ruby_path": "ruby",
 
   //  which rubocop
-  "rubocop_path": "rubocop"
+  "rubocop_path": "rubocop",
+
+  // Apply pretty ruby on entire file if nothing selected
+  "pretty_ruby_prettify_file_on_empty_selection": false
 }


### PR DESCRIPTION
This PR adds support for an opt-in auto formatting of the entire file if there is no selected text. Opt in by setting `"pretty_ruby_prettify_file_on_empty_selection": true` in your sublime settings file.